### PR TITLE
fix: persist the table view state in localStorage

### DIFF
--- a/apps/demo/app/posts-table.tsx
+++ b/apps/demo/app/posts-table.tsx
@@ -25,6 +25,7 @@ export function PostsTable({ data }: PostsTableProps) {
     getRowId: (row) => row.id,
     pageCount: data.total,
     ...tableState,
+    storageKey: "posts-table",
   });
 
   return (


### PR DESCRIPTION
this PR addresses #1 issue. 

#### Problem:
Storing table view configuration only in in-memory state causes the loss of all users' table view preferences on page reload or browser restart.
#### Solution:
Add localStorage persistence to the table's column visibility settings.
* localStorage persistence in useDataTable
* column visibility choices now restore automatically on page reload
* added optional storageKey prop to enable persistance
* gracefull error handling for storage failures

my telegram:
@okkorew